### PR TITLE
Proposal of new properties in pipeline schema and datarecord schema

### DIFF
--- a/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
+++ b/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
@@ -81,6 +81,9 @@
         },
         "metadata": {
           "$ref": "#/definitions/metadata"
+        },
+        "app_data": {
+          "$ref": "#/definitions/app_data_def"
         }
       },
       "required": [
@@ -193,6 +196,13 @@
         }
       },
       "required": []
+    },
+    "app_data_def": {
+      "description": "Object containing app-specific data",
+      "type": "object",
+      "properties": {
+      },
+      "additionalProperties": true
     }
   }
 }

--- a/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
+++ b/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
@@ -176,7 +176,7 @@
           "type": "boolean"
         },
         "is_signed": {
-          "description": "Siged or Unsigned for number (bigint, integer, smallint, tinyint)",
+          "description": "Signed or Unsigned for number (bigint, integer, smallint, tinyint)",
           "type": "boolean"
         },
         "item_index": {

--- a/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
+++ b/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
@@ -135,11 +135,11 @@
           "type": "number"
         },
         "decimal_precision": {
-          "description": "Precision for decimal types",
+          "description": "Precision for decimal, time, and timestamp types",
           "type": "number"
         },
         "decimal_scale": {
-          "description": "Scale for decimal types",
+          "description": "Scale for decimal, time, and timestamp types",
           "type": "number"
         },
         "values": {
@@ -174,10 +174,6 @@
           "description": "Type of runtime",
           "type": "string"
         },
-        "fraction_digits": {
-          "description": "Microsecond length for time and timestamp",
-          "type": "number"
-        },
         "is_key": {
           "description": "A field is key",
           "type": "boolean"
@@ -190,7 +186,7 @@
           "description": "Item record level",
           "type": "number"
         },
-        "source_column_id": {
+        "source_field_id": {
           "description": "Source field for a target field",
           "type": "string"
         }

--- a/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
+++ b/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
@@ -166,6 +166,30 @@
         "runtime_type": {
           "description": "Type of runtime",
           "type": "string"
+        },
+        "fraction_digits": {
+          "description": "Microsecond length for time and timestamp",
+          "type": "number"
+        },
+        "is_key": {
+          "description": "A field is key",
+          "type": "boolean"
+        },
+        "is_signed": {
+          "description": "Siged or Unsigned for number (bigint, integer, smallint, tinyint)",
+          "type": "boolean"
+        },
+        "item_index": {
+          "description": "Item record level",
+          "type": "number"
+        },
+        "min_length": {
+          "description": "Minimum length for fields (binary, bit, char, nchar)",
+          "type": "number"
+        },
+        "source_column_id": {
+          "description": "Source field for a target field",
+          "type": "string"
         }
       },
       "required": []

--- a/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
+++ b/common-pipeline/datarecord-metadata/datarecord-metadata-v3-schema.json
@@ -130,6 +130,10 @@
           "description": "Maximum length for fields. Length is unlimited when not present",
           "type": "number"
         },
+        "min_length": {
+          "description": "Minimum length for fields",
+          "type": "number"
+        },
         "decimal_precision": {
           "description": "Precision for decimal types",
           "type": "number"
@@ -179,15 +183,11 @@
           "type": "boolean"
         },
         "is_signed": {
-          "description": "Signed or Unsigned for number (bigint, integer, smallint, tinyint)",
+          "description": "Signed or Unsigned for number",
           "type": "boolean"
         },
         "item_index": {
           "description": "Item record level",
-          "type": "number"
-        },
-        "min_length": {
-          "description": "Minimum length for fields (binary, bit, char, nchar)",
           "type": "number"
         },
         "source_column_id": {

--- a/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json
+++ b/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json
@@ -94,6 +94,10 @@
           "description": "Unique identifier",
           "type": "string"
         },
+        "description": {
+          "description": "Pipeline flow description",
+          "type": "string"
+        },
         "name": {
           "description": "User-readable name",
           "type": "string"
@@ -155,6 +159,10 @@
           "description": "Unique identifier for node within the current pipeline",
           "type": "string"
         },
+        "description": {
+          "description": "Execution node description",
+          "type": "string"
+        },
         "type": {
           "description": "Node type - always 'execution_node' for non-model pipeline elements",
           "enum": [
@@ -198,6 +206,10 @@
       "properties": {
         "id": {
           "description": "Unique identifier for the supernode within the current pipeline",
+          "type": "string"
+        },
+        "description": {
+          "description": "Super node description",
           "type": "string"
         },
         "type": {
@@ -258,6 +270,10 @@
           "description": "Unique identifier for the binding within the current pipeline",
           "type": "string"
         },
+        "description": {
+          "description": "Binding entry node description",
+          "type": "string"
+        },
         "type": {
           "description": "Node type - always 'binding' for binding elements",
           "enum": [
@@ -301,6 +317,10 @@
           "description": "Unique identifier for the binding within the current pipeline",
           "type": "string"
         },
+        "description": {
+          "description": "Binding exit node description",
+          "type": "string"
+        },
         "type": {
           "description": "Node type - always 'binding' for binding elements",
           "enum": [
@@ -342,6 +362,10 @@
       "properties": {
         "id": {
           "description": "Unique identifier for the model within the current pipeline",
+          "type": "string"
+        },
+        "description": {
+          "description": "Model node description",
           "type": "string"
         },
         "type": {
@@ -491,6 +515,18 @@
         },
         "link_name": {
           "description": "optional link name (used in parameter sets when there are multiple input sources)",
+          "type": "string"
+        },
+        "link_type": {
+          "description": "link type",
+          "enum": [
+            "primary",
+            "secondary",
+            "tertiary"
+          ]
+        },
+        "description": {
+          "description": "link description",
           "type": "string"
         },
         "app_data": {

--- a/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json
+++ b/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json
@@ -209,7 +209,7 @@
           "type": "string"
         },
         "description": {
-          "description": "Super node description",
+          "description": "Supernode description",
           "type": "string"
         },
         "type": {
@@ -518,7 +518,7 @@
           "type": "string"
         },
         "link_type": {
-          "description": "link type",
+          "description": "Link type",
           "enum": [
             "primary",
             "secondary",
@@ -526,7 +526,7 @@
           ]
         },
         "description": {
-          "description": "link description",
+          "description": "Link description",
           "type": "string"
         },
         "app_data": {

--- a/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json
+++ b/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json
@@ -519,11 +519,7 @@
         },
         "link_type": {
           "description": "Link type",
-          "enum": [
-            "primary",
-            "secondary",
-            "tertiary"
-          ]
+          "type": "string"
         },
         "description": {
           "description": "Link description",


### PR DESCRIPTION
 1, pipeline-flow-v3-schema.json
a, Add description to pipeline-def and all types of nodes
b, Add description and link_type to link_def

2, datarecord-metadata-v3-schema.json
Added 6 more properties to field metadata.
Existing decimal_scale only applies to decimal.  Added fraction_digits for time and timestamp for microseconds length.