### PR TITLE
Proposal to add parameters and complex_types to port_definition

### DIFF
--- a/common-pipeline/operators/operator-v3-schema.json
+++ b/common-pipeline/operators/operator-v3-schema.json
@@ -209,19 +209,19 @@
           "additionalProperties": false
         },
         "parameters": {
-      		"description": "List of parameters",
-      		"type": "array",
-      		"items": {
-        		"$ref": "#/definitions/parameter_definition"
-      		}
-    	},
-    	"complex_types": {
-      		"description": "List of complex types",
-      		"type": "array",
-      		"items": {
-        		"$ref": "#/definitions/complex_type_definition"
-      	}
-    	}
+          "description": "List of parameters",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/parameter_definition"
+          }
+        },
+        "complex_types": {
+          "description": "List of complex types",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/complex_type_definition"
+          }
+        }
       }
     },
     "app_data_def": {

--- a/common-pipeline/operators/operator-v3-schema.json
+++ b/common-pipeline/operators/operator-v3-schema.json
@@ -207,7 +207,21 @@
             }
           },
           "additionalProperties": false
-        }
+        },
+        "parameters": {
+      		"description": "List of parameters",
+      		"type": "array",
+      		"items": {
+        		"$ref": "#/definitions/parameter_definition"
+      		}
+    	},
+    	"complex_types": {
+      		"description": "List of complex types",
+      		"type": "array",
+      		"items": {
+        		"$ref": "#/definitions/complex_type_definition"
+      	}
+    	}
       }
     },
     "app_data_def": {


### PR DESCRIPTION

operator-v3-schema.json

- Add parameters and complex_types to port_definition to support parameters for input and output ports.
 - parameters and complex_types are optional for port_definition.