### PR TITLE
#77 Support alternative output from exit binding node (Part 2)

### DIFF
--- a/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json
+++ b/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json
@@ -372,8 +372,8 @@
         "inputs": {
           "$ref": "#/definitions/ports_def"
         },
-        "alt_outputs": {
-          "description": "An alternative set of output ports used for directing error information out of the binding node.",
+        "outputs": {
+          "description": "An optional set of output ports, typically used for directing error information out of the binding node.",
           "$ref": "#/definitions/ports_def"
         },
         "app_data": {


### PR DESCRIPTION
Fixes: #77 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

