### PR TITLE
#86 Added default_value condition definition

### DIFF
--- a/common-pipeline/operators/conditions-v3-schema.json
+++ b/common-pipeline/operators/conditions-v3-schema.json
@@ -611,7 +611,7 @@
           "properties": {
             "parameter_ref": {
               "description": "Parameter whose default value is to be set.",
-              "type": "string",
+              "type": "string"
             },
             "value": {
               "description": "This will be the default value of parameter_ref if condition evaluates to true.",
@@ -627,6 +627,12 @@
                 },
                 {
                   "type": "array"
+                },
+                {
+                  "type": "date"
+                },
+                {
+                  "type": "time"
                 }
               ]
             },

--- a/common-pipeline/operators/conditions-v3-schema.json
+++ b/common-pipeline/operators/conditions-v3-schema.json
@@ -615,25 +615,12 @@
             },
             "value": {
               "description": "This will be the default value of parameter_ref if condition evaluates to true.",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "type": "date"
-                },
-                {
-                  "type": "time"
-                }
+              "type": [
+                "number",
+                "string",
+                "boolean",
+                "object",
+                "array"
               ]
             },
             "evaluate": {

--- a/common-pipeline/operators/conditions-v3-schema.json
+++ b/common-pipeline/operators/conditions-v3-schema.json
@@ -42,6 +42,9 @@
         },
         {
           "$ref": "#/definitions/allow_change_definition"
+        },
+        {
+          "$ref": "#/definitions/default_value_definition"
         }
       ]
     },
@@ -598,6 +601,50 @@
       },
       "required": [
         "allow_change"
+      ]
+    },
+    "default_value_definition": {
+      "properties": {
+        "default_value": {
+          "description": "Set default value of the parameter_ref if condition evaluates to true.",
+          "type": "object",
+          "properties": {
+            "parameter_ref": {
+              "description": "Parameter whose default value is to be set.",
+              "type": "string",
+            },
+            "value": {
+              "description": "This will be the default value of parameter_ref if condition evaluates to true.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "array"
+                }
+              ]
+            },
+            "evaluate": {
+              "description": "Evaluates to a boolean result",
+              "type": "object",
+              "$ref": "#/definitions/evaluate_definition"
+            }
+          },
+          "required": [
+            "parameter_ref",
+            "value",
+            "evaluate"
+          ]
+        }
+      },
+      "required": [
+        "default_value"
       ]
     }
   }


### PR DESCRIPTION
Fixes #86 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

