### PR TITLE
#133 Add an attribute to category in palette to indicate whether the …

### DIFF
--- a/common-canvas/palette/palette-v3-schema.json
+++ b/common-canvas/palette/palette-v3-schema.json
@@ -38,6 +38,10 @@
           "description": "Category description",
           "type": "string"
         },
+        "is_open": {
+          "description": "Boolean to indicate if the category is open (true) or not (false).",
+          "type": "boolean"
+        },
         "empty_text": {
           "description": "When set to a non-empty string and node_types is empty, is used to indicate that no nodes exist",
           "type": "string"


### PR DESCRIPTION
…category is open of not.

Fixes: #133 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

